### PR TITLE
Remove redundant request page build

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,3 @@ git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
 gh-pages -d $PUBLIC_PATH -b gh-pages
-
-curl --request POST -H "Authorization: token ${GITHUB_TOKEN}" \
-  --url "https://api.github.com/repos/$GITHUB_REPOSITORY/pages/builds" \
-  --header 'accept:   application/vnd.github.mister-fantastic-preview+json'


### PR DESCRIPTION
gh-pages pushes a new commit, and the page build would be triggered.
https://developer.github.com/v3/repos/pages/#request-a-page-build